### PR TITLE
Fix: Print a message when failing to open a non-socket device

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+minicom (2.10-1deepin2) unstable; urgency=medium
+
+  * fix: Print a message when failing to open a non-socket device 
+
+ -- zengwei <zengwei1@uniontech.com>  Tue, 21 Apr 2026 10:52:37 +0800
+
 minicom (2.10-1deepin1) unstable; urgency=low
 
   * Set NoDisplay=true for minicom.desktop

--- a/debian/patches/Print-message-when-failing-to-open-non-socket-device.patch
+++ b/debian/patches/Print-message-when-failing-to-open-non-socket-device.patch
@@ -1,0 +1,28 @@
+From da332a2fc8dc80aee9382afa1ac5e76d4b699fe9 Mon Sep 17 00:00:00 2001
+From: zengwei <zengwei1@uniontech.com>
+Date: Mon, 20 Apr 2026 17:08:20 +0800
+Subject: [PATCH] 1
+
+---
+ src/main.c | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/src/main.c b/src/main.c
+index 0dd4a6d..9e7f677 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -408,10 +408,7 @@ nolock:
+     if (portfd_is_socket)
+       term_socket_connect();
+     else
+-      {
+-        if (device_open())
+-	  return -1;
+-      }
++      device_open();
+ 
+     if (portfd >= 0) {
+       if (doinit > 0)
+-- 
+2.50.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 01manual.diff
 04reproducible.diff
+Print-message-when-failing-to-open-non-socket-device.patch


### PR DESCRIPTION
Fix: Print a message when failing to open a non-socket device

pms: 355043